### PR TITLE
Fixing incorrect Grafana TLS variable

### DIFF
--- a/oracles/helm-deployment/setup-grafana.sh
+++ b/oracles/helm-deployment/setup-grafana.sh
@@ -32,7 +32,7 @@ then
     "$script_dir"/scripts/save-env-value.sh "$project" "GRAFANA_TLS_KEY" "$grafana_tls_key" > /dev/null
     grafana_tls_crt=$(base64 "$crt_file")
     printf "\nGRAFANA_TLS_CRT=\"%s\"\n" "$grafana_tls_crt"
-    "$script_dir"/scripts/save-env-value.sh "$project" "GRAFANA_TLS_CRT" "$grafana_tls_key" > /dev/null
+    "$script_dir"/scripts/save-env-value.sh "$project" "GRAFANA_TLS_CRT" "$grafana_tls_crt" > /dev/null
     exit 0
 fi
 


### PR DESCRIPTION
The GRAFANA_TLS_CRT is incorrectly set to the value of $grafana_tls_key instead of $grafana_tls_crt.